### PR TITLE
change promotion-tool link-url

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -84,7 +84,7 @@ export default defineConfig({
 						{ label: '店舗スタッフ向けTOP', link: '/staff/staff/' },
 					],
 				},
-				{ label: 'お役立ちツール', link: 'https://promotion-tool.furusatos.com/' },
+				{ label: 'お役立ちツール', link: '/promotion-tools/' },
 			],
 			lastUpdated: true,
 			pagination: false,

--- a/src/content/docs/index.mdx
+++ b/src/content/docs/index.mdx
@@ -55,7 +55,7 @@ import { LinkCard, CardGrid } from '@astrojs/starlight/components';
     ## リリースノート・お役立ちツール
     <CardGrid>
       <LinkCard title="リリースノート" description="現在準備中です。" href="" />
-      <LinkCard title="お役立ちツール" description="販促にご利用いただけるツールを配布しています。" href="https://promotion-tool.furusatos.com/" target="_blank" />
+      <LinkCard title="お役立ちツール" description="販促にご利用いただけるツールを配布しています。" href="./promotion-tools/" />
     </CardGrid>
   </section>
 </section>


### PR DESCRIPTION
お役立ちツールのURLを既存ページからマニュアルサイト本体へ変更